### PR TITLE
Fully utilize all cores to build

### DIFF
--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -5,11 +5,11 @@ RUN apt-get update && \
     git clone https://github.com/oatpp/oatpp.git && \
     cd oatpp && git checkout tags/1.3.0 && \
     mkdir build && cd build && \
-    cmake -DOATPP_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release .. && make && make install && \
+    cmake -DOATPP_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release .. && make -j $(nproc) && make install && \
     cd ../.. && rm -rf oatpp && \
     apt-get autoremove && apt-get clean
 ADD ./ /vectordb
-RUN mkdir /vectordb/build && cd /vectordb/build && cmake .. && make && chmod +x vectordb
+RUN mkdir /vectordb/build && cd /vectordb/build && cmake .. && make -j $(nproc) && chmod +x vectordb
 
 FROM ubuntu:22.04
 RUN apt-get update && apt-get install -y libgomp1 libboost-all-dev


### PR DESCRIPTION
Single-thread build is too slow, this PR adds the `-j` option with the number of cores on the building machine.