### PR TITLE
feat: Delete by PK

### DIFF
--- a/engine/bindings/python/interface.h
+++ b/engine/bindings/python/interface.h
@@ -14,6 +14,7 @@ static PyObject *insert(PyObject *self, PyObject *args, PyObject *kwargs);
 static PyObject *query(PyObject *self, PyObject *args, PyObject *kwargs);
 static PyObject *drop_table(PyObject *self, PyObject *args, PyObject *kwargs);
 static PyObject *unload_db(PyObject *self, PyObject *args, PyObject *kwargs);
+static PyObject *delete_by_pk(PyObject *self, PyObject *args, PyObject *kwargs);
 
 static std::string db_name;
 static vectordb::engine::DBServer *db;
@@ -26,6 +27,7 @@ static PyMethodDef EpsillaMethods[] = {
     {"insert", (PyCFunction)(void (*)(void))insert, METH_VARARGS | METH_KEYWORDS, "insert record into the database"},
     {"query", (PyCFunction)(void (*)(void))query, METH_VARARGS | METH_KEYWORDS, "query the database"},
     {"drop_table", (PyCFunction)(void (*)(void))drop_table, METH_VARARGS | METH_KEYWORDS, "drop the table"},
+    {"delete_by_pk", (PyCFunction)(void (*)(void))delete_by_pk, METH_VARARGS | METH_KEYWORDS, "delete by primary key"},
     {NULL, NULL, 0, NULL} /* Sentinel */
 };
 

--- a/engine/bindings/python/interface.h
+++ b/engine/bindings/python/interface.h
@@ -27,7 +27,7 @@ static PyMethodDef EpsillaMethods[] = {
     {"insert", (PyCFunction)(void (*)(void))insert, METH_VARARGS | METH_KEYWORDS, "insert record into the database"},
     {"query", (PyCFunction)(void (*)(void))query, METH_VARARGS | METH_KEYWORDS, "query the database"},
     {"drop_table", (PyCFunction)(void (*)(void))drop_table, METH_VARARGS | METH_KEYWORDS, "drop the table"},
-    {"delete_by_pk", (PyCFunction)(void (*)(void))delete_by_pk, METH_VARARGS | METH_KEYWORDS, "delete by primary key"},
+    {"delete", (PyCFunction)(void (*)(void))delete_by_pk, METH_VARARGS | METH_KEYWORDS, "delete by primary key"},
     {NULL, NULL, 0, NULL} /* Sentinel */
 };
 

--- a/engine/db/db_server.cpp
+++ b/engine/db/db_server.cpp
@@ -161,9 +161,9 @@ Status DBServer::DeleteByPK(const std::string& db_name, const std::string& table
     return Status::OK();
   }
   switch (pkField.field_type_) {
-    case meta::FieldType::INT1:
-    case meta::FieldType::INT2:
-    case meta::FieldType::INT4:
+    case meta::FieldType::INT1:  // fall through
+    case meta::FieldType::INT2:  // fall through
+    case meta::FieldType::INT4:  // fall through
     case meta::FieldType::INT8:
       for (int i = 0; i < pkListSize; i++) {
         if (!pkList.GetArrayElement(i).IsNumber()) {

--- a/engine/db/db_server.cpp
+++ b/engine/db/db_server.cpp
@@ -189,7 +189,7 @@ Status DBServer::Search(const std::string& db_name,
                         const std::string& table_name, std::string& field_name,
                         std::vector<std::string>& query_fields,
                         int64_t query_dimension, const float* query_data,
-                        const int64_t K, vectordb::Json& result,
+                        const int64_t limit, vectordb::Json& result,
                         bool with_distance) {
   auto db = GetDB(db_name);
   if (db == nullptr) {
@@ -199,7 +199,7 @@ Status DBServer::Search(const std::string& db_name,
   if (table == nullptr) {
     return Status(DB_UNEXPECTED_ERROR, "Table not found: " + table_name);
   }
-  return table->Search(field_name, query_fields, query_dimension, query_data, K,
+  return table->Search(field_name, query_fields, query_dimension, query_data, limit,
                        result, with_distance);
 }
 

--- a/engine/db/db_server.cpp
+++ b/engine/db/db_server.cpp
@@ -150,7 +150,7 @@ Status DBServer::DeleteByPK(const std::string& db_name, const std::string& table
     }
   }
   if (pkIdx == table->table_schema_.fields_.size()) {
-    return Status(DB_UNEXPECTED_ERROR, "PK not found: " + table_name);
+    return Status(DB_UNEXPECTED_ERROR, "Primary key not found: " + table_name);
   }
 
   // simple sanity check
@@ -167,19 +167,19 @@ Status DBServer::DeleteByPK(const std::string& db_name, const std::string& table
     case meta::FieldType::INT8:
       for (int i = 0; i < pkListSize; i++) {
         if (!pkList.GetArrayElement(i).IsNumber()) {
-          return Status(DB_UNEXPECTED_ERROR, "PK type mismatch at pos " + std::to_string(i));
+          return Status(DB_UNEXPECTED_ERROR, "Primary key type mismatch at field position " + std::to_string(i));
         }
       }
       break;
     case meta::FieldType::STRING:
       for (int i = 0; i < pkListSize; i++) {
         if (!pkList.GetArrayElement(i).IsString()) {
-          return Status(DB_UNEXPECTED_ERROR, "PK type mismatch at pos " + std::to_string(i));
+          return Status(DB_UNEXPECTED_ERROR, "Primary key type mismatch at field position " + std::to_string(i));
         }
       }
       break;
     default:
-      return Status(DB_UNEXPECTED_ERROR, "unexpected PK type.");
+      return Status(DB_UNEXPECTED_ERROR, "unexpected Primary key type.");
   }
 
   return table->DeleteByPK(pkList);

--- a/engine/db/db_server.hpp
+++ b/engine/db/db_server.hpp
@@ -2,19 +2,19 @@
 
 #include <atomic>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <vector>
-#include <thread>
 
 #include "db/catalog/meta.hpp"
-#include "db/table_mvp.hpp"
 #include "db/db_mvp.hpp"
+#include "db/table_mvp.hpp"
 #include "utils/status.hpp"
 
 namespace vectordb {
 namespace engine {
 
-constexpr const long RebuildInterval = 60000; // TODO:: to be config.
+constexpr const long RebuildInterval = 60000;  // TODO:: to be config.
 
 class DBServer {
  public:
@@ -29,24 +29,23 @@ class DBServer {
   std::shared_ptr<DBMVP> GetDB(const std::string& db_name);
   Status ListTables(const std::string& db_name, std::vector<std::string>& table_names);
   Status Insert(const std::string& db_name, const std::string& table_name, vectordb::Json& records);
+  Status DeleteByPK(const std::string& db_name, const std::string& table_name, vectordb::Json& pkList);
   Status Search(
-    const std::string& db_name,
-    const std::string& table_name,
-    std::string& field_name,
-    std::vector<std::string>& query_fields,
-    int64_t query_dimension,
-    const float* query_data,
-    const int64_t K,
-    vectordb::Json& result,
-    bool with_distance
-  );
+      const std::string& db_name,
+      const std::string& table_name,
+      std::string& field_name,
+      std::vector<std::string>& query_fields,
+      int64_t query_dimension,
+      const float* query_data,
+      const int64_t K,
+      vectordb::Json& result,
+      bool with_distance);
 
   Status Project(
-    const std::string& db_name,
-    const std::string& table_name,
-    std::vector<std::string>& query_fields,
-    vectordb::Json& result
-  );
+      const std::string& db_name,
+      const std::string& table_name,
+      std::vector<std::string>& query_fields,
+      vectordb::Json& result);
 
   void StartRebuild() {
     if (rebuild_started_) {
@@ -68,7 +67,7 @@ class DBServer {
   }
 
  private:
-  std::shared_ptr<meta::Meta> meta_;                           // The db meta.
+  std::shared_ptr<meta::Meta> meta_;  // The db meta.
   // TODO: change to concurrent version.
   std::unordered_map<std::string, size_t> db_name_to_id_map_;  // The db name to db index map.
   std::vector<std::shared_ptr<DBMVP>> dbs_;                    // The dbs.
@@ -81,7 +80,7 @@ class DBServer {
     const std::chrono::milliseconds rebuild_interval(RebuildInterval);
 
     while (!stop_rebuild_thread_) {
-      Rebuild(); // Call the Rebuild function
+      Rebuild();  // Call the Rebuild function
 
       // Introduce the time delay before the next Rebuild
       std::this_thread::sleep_for(rebuild_interval);
@@ -90,7 +89,6 @@ class DBServer {
 
   Status Rebuild();
 };
-
 
 }  // namespace engine
 }  // namespace vectordb

--- a/engine/db/db_server.hpp
+++ b/engine/db/db_server.hpp
@@ -37,7 +37,7 @@ class DBServer {
       std::vector<std::string>& query_fields,
       int64_t query_dimension,
       const float* query_data,
-      const int64_t K,
+      const int64_t limit,
       vectordb::Json& result,
       bool with_distance);
 

--- a/engine/db/execution/vec_search_executor.cpp
+++ b/engine/db/execution/vec_search_executor.cpp
@@ -753,13 +753,14 @@ Status VecSearchExecutor::Search(const float *query_data, const ConcurrentBitset
       BruteForceSearch(query_data, total_indexed_vector_, total_vector, deleted);
       // Merge the brute force results into the search result.
       const int64_t master_queue_start = local_queues_starts_[num_threads_ - 1];
+      auto bruteForceQueueSize = std::min({size_t(total_vector - total_indexed_vector_), limit});
       MergeTwoQueuesInto1stQueueSeqFixed(
           set_L_,
           master_queue_start,
           searchLimit,
           brute_force_queue_,
           0,
-          searchLimit);
+          bruteForceQueueSize);
 
       result_size = 0;
       auto candidateNum = std::min({size_t(L_master_), size_t(total_vector)});

--- a/engine/db/execution/vec_search_executor.cpp
+++ b/engine/db/execution/vec_search_executor.cpp
@@ -753,7 +753,7 @@ Status VecSearchExecutor::Search(const float *query_data, const ConcurrentBitset
       BruteForceSearch(query_data, total_indexed_vector_, total_vector, deleted);
       // Merge the brute force results into the search result.
       const int64_t master_queue_start = local_queues_starts_[num_threads_ - 1];
-      auto bruteForceQueueSize = std::min({size_t(total_vector - total_indexed_vector_), limit});
+      auto bruteForceQueueSize = std::min({brute_force_queue_.size(), limit});
       MergeTwoQueuesInto1stQueueSeqFixed(
           set_L_,
           master_queue_start,

--- a/engine/db/execution/vec_search_executor.cpp
+++ b/engine/db/execution/vec_search_executor.cpp
@@ -1,9 +1,10 @@
 #include "db/execution/vec_search_executor.hpp"
-#include "utils/atomic_counter.hpp"
 
 #include <omp.h>
 
 #include <numeric>
+
+#include "utils/atomic_counter.hpp"
 
 namespace vectordb {
 namespace engine {
@@ -670,11 +671,11 @@ void VecSearchExecutor::SearchImpl(
     }  // Search Iterations
   }    // Parallel Phase
 
-// #pragma omp parallel for
-//   // TODO: exclude deleted and not passing filter records.
-//   for (int64_t k_i = 0; k_i < K; ++k_i) {
-//     set_K[k_i] = set_L[k_i + master_queue_start].id_;
-//   }
+  // #pragma omp parallel for
+  //   // TODO: exclude deleted and not passing filter records.
+  //   for (int64_t k_i = 0; k_i < K; ++k_i) {
+  //     set_K[k_i] = set_L[k_i + master_queue_start].id_;
+  //   }
   // for (int64_t k_i = 0; k_i < K; ++k_i) {
   //   std::cout << set_L[k_i + master_queue_start].distance_ << " " << std::endl;
   // }
@@ -700,7 +701,7 @@ bool VecSearchExecutor::BruteForceSearch(const float *query_data, const int64_t 
   return true;
 }
 
-Status VecSearchExecutor::Search(const float *query_data, const int64_t K, const int64_t total, int64_t& result_size) {
+Status VecSearchExecutor::Search(const float *query_data, const int64_t K, const int64_t total, int64_t &result_size) {
   if (K >= L_local_) {
     // TODO: support search for large K.
     return Status(DB_UNEXPECTED_ERROR, "Cannot search more than " + std::to_string(L_local_) + " results.");
@@ -737,12 +738,12 @@ Status VecSearchExecutor::Search(const float *query_data, const int64_t K, const
       // Merge the brute force results into the search result.
       const int64_t master_queue_start = local_queues_starts_[num_threads_ - 1];
       MergeTwoQueuesInto1stQueueSeqFixed(
-        set_L_,
-        master_queue_start,
-        K1,
-        brute_force_queue_,
-        0,
-        K2);
+          set_L_,
+          master_queue_start,
+          K1,
+          brute_force_queue_,
+          0,
+          K2);
       result_size = K < total ? K : total;
       // TODO: exclude deleted and not passing filter records.
 #pragma omp parallel for

--- a/engine/db/execution/vec_search_executor.hpp
+++ b/engine/db/execution/vec_search_executor.hpp
@@ -11,9 +11,9 @@
 #include <unordered_set>
 #include <vector>
 
+#include "db/ann_graph_segment.hpp"
 #include "db/execution/candidate.hpp"
 #include "db/index/space_l2.hpp"
-#include "db/ann_graph_segment.hpp"
 #include "utils/status.hpp"
 
 namespace vectordb {
@@ -24,8 +24,8 @@ constexpr const int BruteforceThreshold = 512;
 
 class VecSearchExecutor {
  public:
-  std::shared_ptr<ANNGraphSegment> ann_index_; // Holding a pointer to make sure it doesn't get released prematurely during rebuild.
-  int64_t ntotal_ = 0;      // The total number of nodes in the graph. Vector table could have more nodes (passed in at search time).
+  std::shared_ptr<ANNGraphSegment> ann_index_;  // Holding a pointer to make sure it doesn't get released prematurely during rebuild.
+  int64_t total_indexed_verctor_ = 0;           // The total number of nodes in the graph. Vector table could have more nodes (passed in at search time).
   int64_t dimension_ = 0;
   int64_t start_search_point_ = 0;
 
@@ -174,17 +174,16 @@ class VecSearchExecutor {
       boost::dynamic_bitset<>& is_visited,
       const int64_t index_threshold);
 
-  bool BruteForceSearch(const float* query_data, const int64_t start, const int64_t end);
-  Status Search(const float* query_data, const int64_t K, const int64_t total, int64_t& result_size);
+  bool BruteForceSearch(const float* query_data, const int64_t start, const int64_t end, const ConcurrentBitset& deleted);
+  Status Search(const float* query_data, const ConcurrentBitset& deleted, const int64_t total, int64_t& result_size);
 };  // Class VecSearchExecutor
 
 }  // namespace execution
 }  // namespace engine
 }  // namespace vectordb
 
-
 /**
- * 
+ *
 
   std::srand(std::time(nullptr));
   int x = 100, y = 100;

--- a/engine/db/execution/vec_search_executor.hpp
+++ b/engine/db/execution/vec_search_executor.hpp
@@ -25,7 +25,7 @@ constexpr const int BruteforceThreshold = 512;
 class VecSearchExecutor {
  public:
   std::shared_ptr<ANNGraphSegment> ann_index_;  // Holding a pointer to make sure it doesn't get released prematurely during rebuild.
-  int64_t total_indexed_verctor_ = 0;           // The total number of nodes in the graph. Vector table could have more nodes (passed in at search time).
+  int64_t total_indexed_vector_ = 0;            // The total number of nodes in the graph. Vector table could have more nodes (passed in at search time).
   int64_t dimension_ = 0;
   int64_t start_search_point_ = 0;
 
@@ -175,7 +175,7 @@ class VecSearchExecutor {
       const int64_t index_threshold);
 
   bool BruteForceSearch(const float* query_data, const int64_t start, const int64_t end, const ConcurrentBitset& deleted);
-  Status Search(const float* query_data, const ConcurrentBitset& deleted, const int64_t total, int64_t& result_size);
+  Status Search(const float* query_data, const ConcurrentBitset& deleted, const size_t limit, const int64_t total, int64_t& result_size);
 };  // Class VecSearchExecutor
 
 }  // namespace execution

--- a/engine/db/table_mvp.cpp
+++ b/engine/db/table_mvp.cpp
@@ -238,8 +238,6 @@ Status TableMVP::Project(
     from_id_list = false;
   }
 
-  auto pkfieldIdx = table_segment_->pkFieldIdx();
-
   for (auto i = 0; i < idlist_size; ++i) {
     int64_t id = from_id_list ? ids[i] : i;
     if (table_segment_->isEntryDeleted(id)) {

--- a/engine/db/table_mvp.cpp
+++ b/engine/db/table_mvp.cpp
@@ -207,6 +207,8 @@ Status TableMVP::Search(const std::string &field_name,
   int64_t result_num = 0;
   executor.exec_->Search(query_data, *table_segment_->deleted_, table_segment_->record_number_,
                          result_num);
+
+  result_num = result_num > K ? K : result_num;
   auto status =
       Project(query_fields, result_num, executor.exec_->search_result_, result,
               with_distance, executor.exec_->distance_);

--- a/engine/db/table_mvp.cpp
+++ b/engine/db/table_mvp.cpp
@@ -9,15 +9,6 @@
 namespace vectordb {
 namespace engine {
 
-constexpr const int IntraQueryThreads = 4;
-constexpr const int MasterQueueSize = 500;
-constexpr const int LocalQueueSize = 500;
-constexpr const int GlobalSyncInterval = 15;
-constexpr const int MinimalGraphSize = 100;
-constexpr const int NumExecutorPerField = 16;
-
-constexpr const int RebuildThreads = 4;
-
 TableMVP::TableMVP(meta::TableSchema &table_schema,
                    const std::string &db_catalog_path, int64_t init_table_scale)
     : table_schema_(table_schema),
@@ -205,7 +196,7 @@ Status TableMVP::Search(const std::string &field_name,
 
   // Search.
   int64_t result_num = 0;
-  executor.exec_->Search(query_data, *table_segment_->deleted_, table_segment_->record_number_,
+  executor.exec_->Search(query_data, *table_segment_->deleted_, limit, table_segment_->record_number_,
                          result_num);
 
   result_num = result_num > limit ? limit : result_num;

--- a/engine/db/table_mvp.cpp
+++ b/engine/db/table_mvp.cpp
@@ -205,7 +205,7 @@ Status TableMVP::Search(const std::string &field_name,
 
   // Search.
   int64_t result_num = 0;
-  executor.exec_->Search(query_data, K, table_segment_->record_number_,
+  executor.exec_->Search(query_data, *table_segment_->deleted_, table_segment_->record_number_,
                          result_num);
   auto status =
       Project(query_fields, result_num, executor.exec_->search_result_, result,
@@ -240,9 +240,6 @@ Status TableMVP::Project(
 
   for (auto i = 0; i < idlist_size; ++i) {
     int64_t id = from_id_list ? ids[i] : i;
-    if (table_segment_->isEntryDeleted(id)) {
-      continue;
-    }
     vectordb::Json record;
     record.LoadFromString("{}");
     for (auto field : query_fields) {

--- a/engine/db/table_mvp.cpp
+++ b/engine/db/table_mvp.cpp
@@ -166,7 +166,7 @@ Status TableMVP::DeleteByPK(vectordb::Json &records) {
 Status TableMVP::Search(const std::string &field_name,
                         std::vector<std::string> &query_fields,
                         int64_t query_dimension, const float *query_data,
-                        const int64_t K, vectordb::Json &result,
+                        const int64_t limit, vectordb::Json &result,
                         bool with_distance) {
   // Check if field_name exists.
   if (field_name_type_map_.find(field_name) == field_name_type_map_.end()) {
@@ -208,7 +208,7 @@ Status TableMVP::Search(const std::string &field_name,
   executor.exec_->Search(query_data, *table_segment_->deleted_, table_segment_->record_number_,
                          result_num);
 
-  result_num = result_num > K ? K : result_num;
+  result_num = result_num > limit ? limit : result_num;
   auto status =
       Project(query_fields, result_num, executor.exec_->search_result_, result,
               with_distance, executor.exec_->distance_);

--- a/engine/db/table_mvp.cpp
+++ b/engine/db/table_mvp.cpp
@@ -321,7 +321,7 @@ Status TableMVP::Project(
     if (with_distance) {
       record.SetDouble("@distance", distances[i]);
     }
-    result.AddObjectToArray(record);
+    result.AddObjectToArray(std::move(record));
   }
   return Status::OK();
 }

--- a/engine/db/table_mvp.cpp
+++ b/engine/db/table_mvp.cpp
@@ -160,7 +160,6 @@ Status TableMVP::Insert(vectordb::Json &record) {
 Status TableMVP::DeleteByPK(vectordb::Json &records) {
   int64_t wal_id =
       wal_->WriteEntry(LogEntryType::DELETE, records.DumpToString());
-
   return table_segment_->DeleteByPK(records, wal_id);
 }
 
@@ -239,8 +238,13 @@ Status TableMVP::Project(
     from_id_list = false;
   }
 
+  auto pkfieldIdx = table_segment_->pkFieldIdx();
+
   for (auto i = 0; i < idlist_size; ++i) {
     int64_t id = from_id_list ? ids[i] : i;
+    if (table_segment_->isEntryDeleted(id)) {
+      continue;
+    }
     vectordb::Json record;
     record.LoadFromString("{}");
     for (auto field : query_fields) {

--- a/engine/db/table_mvp.cpp
+++ b/engine/db/table_mvp.cpp
@@ -126,14 +126,18 @@ Status TableMVP::Rebuild(const std::string &db_catalog_path) {
             table_segment_->record_number_,
             table_schema_.fields_[i].vector_dimension_,
             ann_graph_segment_[index]->navigation_point_,
-            ann_graph_segment_[index], ann_graph_segment_[index]->offset_table_,
+            ann_graph_segment_[index],
+            ann_graph_segment_[index]->offset_table_,
             ann_graph_segment_[index]->neighbor_list_,
             table_segment_
                 ->vector_tables_[table_segment_->field_name_mem_offset_map_
                                      [table_schema_.fields_[i].name_]],
             l2space_[index]->get_dist_func(),
-            l2space_[index]->get_dist_func_param(), IntraQueryThreads,
-            MasterQueueSize, LocalQueueSize, GlobalSyncInterval));
+            l2space_[index]->get_dist_func_param(),
+            IntraQueryThreads,
+            MasterQueueSize,
+            LocalQueueSize,
+            GlobalSyncInterval));
       }
       std::unique_lock<std::mutex> lock(executor_pool_mutex_);
       executor_pool_.set(index, pool);
@@ -151,6 +155,13 @@ Status TableMVP::Insert(vectordb::Json &record) {
   int64_t wal_id =
       wal_->WriteEntry(LogEntryType::INSERT, record.DumpToString());
   return table_segment_->Insert(table_schema_, record, wal_id);
+}
+
+Status TableMVP::DeleteByPK(vectordb::Json &records) {
+  int64_t wal_id =
+      wal_->WriteEntry(LogEntryType::DELETE, records.DumpToString());
+
+  return table_segment_->DeleteByPK(records, wal_id);
 }
 
 Status TableMVP::Search(const std::string &field_name,

--- a/engine/db/table_mvp.hpp
+++ b/engine/db/table_mvp.hpp
@@ -30,6 +30,8 @@ class TableMVP {
 
   Status Insert(vectordb::Json &records);
 
+  Status DeleteByPK(vectordb::Json &records);
+
   Status Search(
       const std::string &field_name,
       std::vector<std::string> &query_fields,

--- a/engine/db/table_mvp.hpp
+++ b/engine/db/table_mvp.hpp
@@ -37,7 +37,7 @@ class TableMVP {
       std::vector<std::string> &query_fields,
       int64_t query_dimension,
       const float *query_data,
-      const int64_t K,
+      const int64_t limit,
       vectordb::Json &result,
       bool with_distance);
 

--- a/engine/db/table_mvp.hpp
+++ b/engine/db/table_mvp.hpp
@@ -21,6 +21,15 @@
 namespace vectordb {
 namespace engine {
 
+constexpr const int IntraQueryThreads = 4;
+constexpr const int MasterQueueSize = 500;
+constexpr const int LocalQueueSize = 500;
+constexpr const int GlobalSyncInterval = 15;
+constexpr const int MinimalGraphSize = 100;
+constexpr const int NumExecutorPerField = 16;
+
+constexpr const int RebuildThreads = 4;
+
 class TableMVP {
  public:
   explicit TableMVP(meta::TableSchema &table_schema, const std::string &db_catalog_path, int64_t init_table_scale /*, int64_t executors_num*/);

--- a/engine/db/table_segment_mvp.cpp
+++ b/engine/db/table_segment_mvp.cpp
@@ -153,6 +153,7 @@ TableSegmentMVP::TableSegmentMVP(meta::TableSchema& table_schema, const std::str
     if (isIntPK()) {
       auto field = table_schema.fields_[*pk_field_idx_];
       for (auto rIdx = 0; rIdx < record_number_; rIdx++) {
+        // skip deleted entry
         if (deleted_->test(rIdx)) {
           continue;
         }
@@ -194,6 +195,11 @@ TableSegmentMVP::TableSegmentMVP(meta::TableSchema& table_schema, const std::str
 
     // Read the string table
     for (auto i = 0; i < record_number_; ++i) {
+      // skip deleted entry
+      if (deleted_->test(i)) {
+        continue;
+      }
+
       for (auto j = 0; j < string_num_; ++j) {
         int64_t offset = i * string_num_ + j;
         int64_t string_length = 0;

--- a/engine/db/table_segment_mvp.cpp
+++ b/engine/db/table_segment_mvp.cpp
@@ -47,6 +47,7 @@ constexpr size_t FieldTypeSizeMVP(meta::FieldType type) {
 Status TableSegmentMVP::Init(meta::TableSchema& table_schema, int64_t size_limit) {
   size_limit_ = size_limit;
   primitive_offset_ = 0;
+  schema_ptr_ = &table_schema;
 
   // Get how many primitive, vectors, and strings attributes.
   for (auto& field_schema : table_schema.fields_) {
@@ -68,10 +69,11 @@ Status TableSegmentMVP::Init(meta::TableSchema& table_schema, int64_t size_limit
       field_id_mem_offset_map_[field_schema.id_] = primitive_offset_;
       field_name_mem_offset_map_[field_schema.name_] = primitive_offset_;
       primitive_offset_ += FieldTypeSizeMVP(field_schema.field_type_);
-      if (field_schema.is_primary_key_) {
-        primitive_pk_field_id_ = std::make_unique<int64_t>(field_schema.id_);
-      }
       ++primitive_num_;
+    }
+
+    if (field_schema.is_primary_key_) {
+      pk_field_idx_ = std::make_unique<int64_t>(field_schema.id_);
     }
   }
 
@@ -148,9 +150,12 @@ TableSegmentMVP::TableSegmentMVP(meta::TableSchema& table_schema, const std::str
     file.read(attribute_table_, record_number_ * primitive_offset_);
 
     // add pk into set
-    if (primitive_pk_field_id_) {
-      auto field = table_schema.fields_[*primitive_pk_field_id_];
+    if (isIntPK()) {
+      auto field = table_schema.fields_[*pk_field_idx_];
       for (auto rIdx = 0; rIdx < record_number_; rIdx++) {
+        if (deleted_->test(rIdx)) {
+          continue;
+        }
         switch (field.field_type_) {
           case meta::FieldType::INT1: {
             int8_t value = 0;
@@ -225,6 +230,65 @@ TableSegmentMVP::TableSegmentMVP(meta::TableSchema& table_schema, const std::str
       throw status.message();
     }
   }
+}
+
+bool TableSegmentMVP::isStringPK() const {
+  string_pk_offset_;
+}
+
+bool TableSegmentMVP::isIntPK() const {
+  pk_field_idx_ && !string_pk_offset_;
+}
+
+meta::FieldType TableSegmentMVP::pkType() const {
+  schema_ptr_->fields_[*pk_field_idx_].field_type_;
+}
+
+Status TableSegmentMVP::DeleteByPK(Json& records, int64_t wal_id) {
+  wal_global_id_ = wal_id;
+  size_t new_record_size = records.GetSize();
+  if (new_record_size == 0) {
+    std::cout << "No records to delete." << std::endl;
+    return Status::OK();
+  }
+  if (isIntPK()) {
+    auto fieldType = pkType();
+    for (auto i = 0; i < new_record_size; ++i) {
+      auto pkField = records.GetArrayElement(i);
+      auto pk = pkField.GetInt();
+      switch (pkType()) {
+        case meta::FieldType::INT1:
+          DeleteByIntPK(static_cast<int8_t>(pk));
+          break;
+        case meta::FieldType::INT2:
+          DeleteByIntPK(static_cast<int16_t>(pk));
+          break;
+        case meta::FieldType::INT4:
+          DeleteByIntPK(static_cast<int32_t>(pk));
+          break;
+        case meta::FieldType::INT8:
+          DeleteByIntPK(static_cast<int64_t>(pk));
+          break;
+      }
+    }
+  } else if (isStringPK()) {
+    for (auto i = 0; i < new_record_size; ++i) {
+      auto pkField = records.GetArrayElement(i);
+      auto pk = pkField.GetString();
+      DeleteByStringPK(pk);
+    }
+  }
+}
+
+Status TableSegmentMVP::DeleteByStringPK(const std::string& pk) {
+  size_t result = 0;
+  auto found = primary_key_.getKey(pk, result);
+  if (found) {
+    deleted_->set(result);
+    primary_key_.removeKey(pk);
+    return Status::OK();
+  }
+  return Status(RECORD_NOT_FOUND, "could not find record with primary key: " + pk);
 }
 
 // Status TableSegmentMVP::DoubleSize() {
@@ -398,7 +462,7 @@ Status TableSegmentMVP::Insert(meta::TableSchema& table_schema, Json& records, i
     }
     ++cursor;
 
-  LOOP_END : {}
+  LOOP_END: {}
     // nothing should be done at the end of block
   }
   record_number_.store(cursor);

--- a/engine/db/table_segment_mvp.cpp
+++ b/engine/db/table_segment_mvp.cpp
@@ -195,11 +195,6 @@ TableSegmentMVP::TableSegmentMVP(meta::TableSchema& table_schema, const std::str
 
     // Read the string table
     for (auto i = 0; i < record_number_; ++i) {
-      // skip deleted entry
-      if (deleted_->test(i)) {
-        continue;
-      }
-
       for (auto j = 0; j < string_num_; ++j) {
         int64_t offset = i * string_num_ + j;
         int64_t string_length = 0;
@@ -209,7 +204,7 @@ TableSegmentMVP::TableSegmentMVP(meta::TableSchema& table_schema, const std::str
         string_table_[offset] = str;
 
         // add pk into set
-        if (string_pk_offset_ && *string_pk_offset_ == j) {
+        if (!deleted_->test(i) && string_pk_offset_ && *string_pk_offset_ == j) {
           // do not check existance to avoid additional overhead
           primary_key_.addKeyIfNotExist(str, i);
         }

--- a/engine/db/table_segment_mvp.cpp
+++ b/engine/db/table_segment_mvp.cpp
@@ -259,6 +259,7 @@ bool TableSegmentMVP::isEntryDeleted(int64_t id) const {
 
 Status TableSegmentMVP::DeleteByPK(Json& records, int64_t wal_id) {
   wal_global_id_ = wal_id;
+  size_t deleted_record = 0;
   size_t new_record_size = records.GetSize();
   if (new_record_size == 0) {
     std::cout << "No records to delete." << std::endl;
@@ -271,16 +272,16 @@ Status TableSegmentMVP::DeleteByPK(Json& records, int64_t wal_id) {
       auto pk = pkField.GetInt();
       switch (pkType()) {
         case meta::FieldType::INT1:
-          DeleteByIntPK(static_cast<int8_t>(pk));
+          deleted_record += DeleteByIntPK(static_cast<int8_t>(pk)).ok();
           break;
         case meta::FieldType::INT2:
-          DeleteByIntPK(static_cast<int16_t>(pk));
+          deleted_record += DeleteByIntPK(static_cast<int16_t>(pk)).ok();
           break;
         case meta::FieldType::INT4:
-          DeleteByIntPK(static_cast<int32_t>(pk));
+          deleted_record += DeleteByIntPK(static_cast<int32_t>(pk)).ok();
           break;
         case meta::FieldType::INT8:
-          DeleteByIntPK(static_cast<int64_t>(pk));
+          deleted_record += DeleteByIntPK(static_cast<int64_t>(pk)).ok();
           break;
       }
     }
@@ -288,10 +289,10 @@ Status TableSegmentMVP::DeleteByPK(Json& records, int64_t wal_id) {
     for (auto i = 0; i < new_record_size; ++i) {
       auto pkField = records.GetArrayElement(i);
       auto pk = pkField.GetString();
-      DeleteByStringPK(pk);
+      deleted_record += DeleteByStringPK(pk).ok();
     }
   }
-  return Status::OK();
+  return Status(DB_SUCCESS, "successfully deleted " + std::to_string(deleted_record) + " records.");
 }
 
 Status TableSegmentMVP::DeleteByStringPK(const std::string& pk) {

--- a/engine/db/table_segment_mvp.hpp
+++ b/engine/db/table_segment_mvp.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <iostream>
 #include <string>
 #include <typeinfo>
 #include <unordered_map>
@@ -73,6 +74,9 @@ class TableSegmentMVP {
   bool isIntPK() const;
   bool isStringPK() const;
   meta::FieldType pkType() const;
+  meta::FieldSchema pkField() const;
+  int64_t pkFieldIdx() const;
+  bool isEntryDeleted(int64_t id) const;
 
  private:
   // used to store primary key set for duplication check
@@ -87,7 +91,7 @@ class TableSegmentMVP {
   // save a copy of the schema - the lifecycle of the schema is not managed by the segment, so
   // we can keep the raw pointer here. In addition, the table_segment_mvp's lifecycle is always longer
   // than the owner, so so don't need to worry about invalid pointer here.
-  meta::TableSchema* schema_ptr_;
+  meta::TableSchema schema;
 
   Status DeleteByStringPK(const std::string& pk);
 

--- a/engine/db/table_segment_mvp.hpp
+++ b/engine/db/table_segment_mvp.hpp
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <string>
+#include <typeinfo>
 #include <unordered_map>
 
 #include "db/catalog/meta.hpp"
@@ -38,6 +39,8 @@ class TableSegmentMVP {
   Status Insert(meta::TableSchema& table_schema, Json& records);
   Status Insert(meta::TableSchema& table_schema, Json& records, int64_t wal_id);
 
+  Status DeleteByPK(Json& records, int64_t wal_id);
+
   // Save the table segment to disk.
   Status SaveTableSegment(meta::TableSchema& table_schema, const std::string& db_catalog_path);
 
@@ -67,15 +70,38 @@ class TableSegmentMVP {
                                // The deleted records still occupy the position in all other structures.
                                // They should be skipped during search.
 
+  bool isIntPK() const;
+  bool isStringPK() const;
+  meta::FieldType pkType() const;
+
  private:
   // used to store primary key set for duplication check
   UniqueKey primary_key_;
-  // The id of primitive primary key
-  // primitive_pk_field_id_.get() != nullptr if there's a primitive pk
-  std::unique_ptr<int64_t> primitive_pk_field_id_;
+  // The index of primary key in schema fields
+  // pk_field_id_.get() != nullptr if there's a pk
+  std::unique_ptr<int64_t> pk_field_idx_;
   // The index of primary key among string keys
   // string_pk_offset_.get() != nullptr if there's a string pk
   std::unique_ptr<int64_t> string_pk_offset_;
+
+  // save a copy of the schema - the lifecycle of the schema is not managed by the segment, so
+  // we can keep the raw pointer here. In addition, the table_segment_mvp's lifecycle is always longer
+  // than the owner, so so don't need to worry about invalid pointer here.
+  meta::TableSchema* schema_ptr_;
+
+  Status DeleteByStringPK(const std::string& pk);
+
+  template <typename T>
+  Status DeleteByIntPK(T pk) {
+    size_t result = 0;
+    auto found = primary_key_.getKey(pk, result);
+    if (found) {
+      deleted_->set(result);
+      primary_key_.removeKey(pk);
+      return Status::OK();
+    }
+    return Status(RECORD_NOT_FOUND, "could not find record with primary key: " + pk);
+  }
 
   // std::shared_ptr<AttributeTable> attribute_table_;  // The attribute table in memory (exclude vector attributes and string attributes).
   // std::shared_ptr<std::string*> string_table_;       // The string attribute table in memory.

--- a/engine/db/wal/write_ahead_log.hpp
+++ b/engine/db/wal/write_ahead_log.hpp
@@ -151,10 +151,10 @@ class WriteAheadLog {
 
  private:
   void ApplyEntry(meta::TableSchema &table_schema, std::shared_ptr<TableSegmentMVP> segment, int64_t global_id, LogEntryType &type, std::string &content) {
+    vectordb::Json record;
+    record.LoadFromString(content);
     switch (type) {
       case LogEntryType::INSERT: {
-        Json record;
-        record.LoadFromString(content);
         auto status = segment->Insert(table_schema, record, global_id);
         if (!status.ok()) {
           std::cout << "Fail to apply wal entry: " << status.message() << std::endl;
@@ -162,7 +162,10 @@ class WriteAheadLog {
         break;
       }
       case LogEntryType::DELETE: {
-        // TODO: to be implemented.
+        auto status = segment->DeleteByPK(record, global_id);
+        if (!status.ok()) {
+          std::cout << "Fail to apply wal entry: " << status.message() << std::endl;
+        }
         break;
       }
       default: {

--- a/engine/server/web_server/dto/status_dto.hpp
+++ b/engine/server/web_server/dto/status_dto.hpp
@@ -36,17 +36,6 @@ class TableListDto : public oatpp::DTO {
   DTO_FIELD(List<String>, result);
 };
 
-class DeleteRecordsReqDto : public oatpp::DTO {
-  DTO_INIT(DeleteRecordsReqDto, DTO)
-
-  DTO_FIELD_INFO(table) {
-    info->required = true;
-  }
-
-  DTO_FIELD(String, table);
-  DTO_FIELD(oatpp::List<oatpp::String>, ids);
-};
-
 class SearchRespDto : public oatpp::DTO {
   DTO_INIT(SearchRespDto, DTO);
 

--- a/engine/server/web_server/dto/status_dto.hpp
+++ b/engine/server/web_server/dto/status_dto.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <oatpp/core/Types.hpp>
-#include <oatpp/core/macro/codegen.hpp>
 #include <oatpp/core/data/mapping/type/Any.hpp>
+#include <oatpp/core/macro/codegen.hpp>
 
 #include "db/catalog/meta.hpp"
 #include "utils/json.hpp"
@@ -13,51 +13,50 @@ namespace web {
 
 #include OATPP_CODEGEN_BEGIN(DTO)
 
-class StatusDto: public oatpp::DTO {
+class StatusDto : public oatpp::DTO {
+  DTO_INIT(StatusDto, DTO)
 
-    DTO_INIT(StatusDto, DTO)
-
-    DTO_FIELD(Int32, statusCode);
-    DTO_FIELD(String, message);
+  DTO_FIELD(Int32, statusCode);
+  DTO_FIELD(String, message);
 };
 
-class SchemaInfoDto: public oatpp::DTO {
-    DTO_INIT(SchemaInfoDto, DTO)
+class SchemaInfoDto : public oatpp::DTO {
+  DTO_INIT(SchemaInfoDto, DTO)
 
-    DTO_FIELD(Int32, statusCode);
-    DTO_FIELD(String, message);
-    // DTO_FIELD(Object<vectordb::engine::meta::TableSchema>, result);
+  DTO_FIELD(Int32, statusCode);
+  DTO_FIELD(String, message);
+  // DTO_FIELD(Object<vectordb::engine::meta::TableSchema>, result);
 };
 
 class TableListDto : public oatpp::DTO {
-    DTO_INIT(TableListDto, DTO)
+  DTO_INIT(TableListDto, DTO)
 
-    DTO_FIELD(Int32, statusCode);
-    DTO_FIELD(String, message);
-    DTO_FIELD(List<String>, result);
+  DTO_FIELD(Int32, statusCode);
+  DTO_FIELD(String, message);
+  DTO_FIELD(List<String>, result);
 };
 
 class DeleteRecordsReqDto : public oatpp::DTO {
-    DTO_INIT(DeleteRecordsReqDto, DTO)
+  DTO_INIT(DeleteRecordsReqDto, DTO)
 
-    DTO_FIELD_INFO(table) {
-        info->required = true;
-    }
+  DTO_FIELD_INFO(table) {
+    info->required = true;
+  }
 
-    DTO_FIELD(String, table);
-    DTO_FIELD(oatpp::List<oatpp::String>, ids);
+  DTO_FIELD(String, table);
+  DTO_FIELD(oatpp::List<oatpp::String>, ids);
 };
 
 class SearchRespDto : public oatpp::DTO {
-    DTO_INIT(SearchRespDto, DTO);
+  DTO_INIT(SearchRespDto, DTO);
 
-    DTO_FIELD(Int32, statusCode);
-    DTO_FIELD(String, message);
-    DTO_FIELD(Any::ObjectWrapper, result);
+  DTO_FIELD(Int32, statusCode);
+  DTO_FIELD(String, message);
+  DTO_FIELD(Any::ObjectWrapper, result);
 };
 
 #include OATPP_CODEGEN_END(DTO)
 
-}
-}
-}
+}  // namespace web
+}  // namespace server
+}  // namespace vectordb

--- a/engine/server/web_server/web_controller.hpp
+++ b/engine/server/web_server/web_controller.hpp
@@ -374,6 +374,7 @@ class WebController : public oatpp::web::server::api::ApiController {
     auto responseCode = Status::CODE_200;
     if (status.ok()) {
       dto->statusCode = Status::CODE_200.code;
+      dto->message = status.message();
     } else {
       responseCode = Status::CODE_400;
       dto->statusCode = Status::CODE_400.code;

--- a/engine/server/web_server/web_controller.hpp
+++ b/engine/server/web_server/web_controller.hpp
@@ -356,7 +356,14 @@ class WebController : public oatpp::web::server::api::ApiController {
            BODY_STRING(String, body)) {
     auto dto = StatusDto::createShared();
     vectordb::Json requestBody;
-    requestBody.LoadFromString(body);
+    auto valid = requestBody.LoadFromString(body);
+
+    if (!valid) {
+      dto->statusCode = Status::CODE_400.code;
+      dto->message = "Invalid payload.";
+      return createDtoResponse(Status::CODE_400, dto);
+    }
+
     if (!requestBody.HasMember("table")) {
       dto->statusCode = Status::CODE_400.code;
       dto->message = "Missing table name in your payload.";

--- a/engine/server/web_server/web_controller.hpp
+++ b/engine/server/web_server/web_controller.hpp
@@ -351,7 +351,7 @@ class WebController : public oatpp::web::server::api::ApiController {
 
   ADD_CORS(DeleteRecordsByPK)
 
-  ENDPOINT("POST", "/api/{db_name}/data/delete/pk", DeleteRecordsByPK,
+  ENDPOINT("POST", "/api/{db_name}/data/delete", DeleteRecordsByPK,
            PATH(String, db_name, "db_name"),
            BODY_STRING(String, body)) {
     auto dto = StatusDto::createShared();
@@ -380,40 +380,6 @@ class WebController : public oatpp::web::server::api::ApiController {
       dto->message = status.message();
     }
     return createDtoResponse(responseCode, dto);
-  }
-
-  // TODO: implement with corresponding function later.
-  ADD_CORS(DeleteRecordsByID)
-
-  ENDPOINT("POST", "/api/{db_name}/data/delete", DeleteRecordsByID,
-           PATH(String, db_name, "db_name"),
-           BODY_DTO(Object<DeleteRecordsReqDto>, body)) {
-    auto dto = StatusDto::createShared();
-
-    if (!body->table) {
-      dto->statusCode = Status::CODE_400.code;
-      dto->message = "Missing table name in your payload.";
-      return createDtoResponse(Status::CODE_400, dto);
-    }
-    if (!body->ids) {
-      dto->statusCode = Status::CODE_400.code;
-      dto->message = "Missing ID list to delete in your payload.";
-      return createDtoResponse(Status::CODE_400, dto);
-    }
-
-    const auto& body_ids = body->ids;
-    if (body_ids->size() == 0) {
-      dto->statusCode = Status::CODE_400.code;
-      dto->message = "No IDs to delete provided.";
-      return createDtoResponse(Status::CODE_400, dto);
-    }
-    std::vector<std::string> arr;
-    for (size_t i = 0; i < body_ids->size(); i++) {
-      arr.push_back(body_ids[i]);
-    }
-    dto->statusCode = Status::CODE_200.code;
-    dto->message = "Deleted " + WebUtil::JoinStrs(arr, ", ") + " from " + body->table + " in " + db_name + " successfully.";
-    return createDtoResponse(Status::CODE_200, dto);
   }
 
   // TODO: implement with corresponding function later.

--- a/engine/test.sh
+++ b/engine/test.sh
@@ -1,8 +1,8 @@
 export PYTHONPATH=./build/ 
 export DB_PATH=/tmp/db2
 rm -rf "$DB_PATH"
-echo $1
 if [ "$1" == "--single-thread" ]; then
+  echo "running single-thread mode"
   python3 test/bindings/python/test.py
 else
   python3 test/bindings/python/concurrent_test.py

--- a/engine/test/bindings/python/test.py
+++ b/engine/test/bindings/python/test.py
@@ -37,8 +37,9 @@ epsilla.insert(
 
 print(code, response)
 
-code = epsilla.delete_by_pk(table_name="MyTable", primary_keys=[1, 2, 3, 4])
-
+pk_to_delete = [1, 2, 3, 4]
+print("deleting pk ", pk_to_delete)
+code = epsilla.delete_by_pk(table_name="MyTable", primary_keys=pk_to_delete)
 print("delete_by_pk return code:", code)
 
 (code, response) = epsilla.query(

--- a/engine/test/bindings/python/test.py
+++ b/engine/test/bindings/python/test.py
@@ -34,7 +34,23 @@ epsilla.insert(
     limit=2,
     with_distance=True
 )
+
 print(code, response)
+
+code = epsilla.delete_by_pk(table_name="MyTable", primary_keys=[1, 2, 3, 4])
+
+print("delete_by_pk:", code)
+
+(code, response) = epsilla.query(
+    table_name="MyTable",
+    query_field="Embedding",
+    response_fields=["ID", "Doc", "Embedding"],
+    query_vector=[0.35, 0.55, 0.47, 0.94],
+    limit=10,
+    with_distance=True
+)
+print(code, response)
+exit(0)
 
 epsilla.drop_table("MyTable")
 

--- a/engine/test/bindings/python/test.py
+++ b/engine/test/bindings/python/test.py
@@ -39,7 +39,7 @@ print(code, response)
 
 code = epsilla.delete_by_pk(table_name="MyTable", primary_keys=[1, 2, 3, 4])
 
-print("delete_by_pk:", code)
+print("delete_by_pk return code:", code)
 
 (code, response) = epsilla.query(
     table_name="MyTable",
@@ -50,7 +50,6 @@ print("delete_by_pk:", code)
     with_distance=True
 )
 print(code, response)
-exit(0)
 
 epsilla.drop_table("MyTable")
 

--- a/engine/test/bindings/python/test.py
+++ b/engine/test/bindings/python/test.py
@@ -39,8 +39,8 @@ print(code, response)
 
 pk_to_delete = [1, 2, 3, 4]
 print("deleting pk ", pk_to_delete)
-code = epsilla.delete_by_pk(table_name="MyTable", primary_keys=pk_to_delete)
-print("delete_by_pk return code:", code)
+code = epsilla.delete(table_name="MyTable", primary_keys=pk_to_delete)
+print("delete return code:", code)
 
 (code, response) = epsilla.query(
     table_name="MyTable",

--- a/engine/utils/concurrent_bitset.cpp
+++ b/engine/utils/concurrent_bitset.cpp
@@ -6,7 +6,7 @@ ConcurrentBitset::ConcurrentBitset(id_type_t capacity)
     : capacity_(capacity), bitset_((capacity + 8 - 1) >> 3) {
 }
 
-bool ConcurrentBitset::test(id_type_t id) {
+bool ConcurrentBitset::test(id_type_t id) const {
   return bitset_[id >> 3].load() & (0x1 << (id & 0x7));
 }
 

--- a/engine/utils/concurrent_bitset.hpp
+++ b/engine/utils/concurrent_bitset.hpp
@@ -12,7 +12,7 @@ class ConcurrentBitset {
 
   explicit ConcurrentBitset(id_type_t size);
 
-  bool test(id_type_t id);
+  bool test(id_type_t id) const;
   void set(id_type_t id);
   void clear(id_type_t id);
 

--- a/engine/utils/error.hpp
+++ b/engine/utils/error.hpp
@@ -32,6 +32,7 @@ constexpr ErrorCode DB_NOT_FOUND = ToDbErrorCode(3);
 constexpr ErrorCode TABLE_ALREADY_EXISTS = ToDbErrorCode(4);
 constexpr ErrorCode TABLE_NOT_FOUND = ToDbErrorCode(5);
 constexpr ErrorCode INVALID_RECORD = ToDbErrorCode(6);
+constexpr ErrorCode RECORD_NOT_FOUND = ToDbErrorCode(7);
 
 namespace server {
 

--- a/engine/utils/json.cpp
+++ b/engine/utils/json.cpp
@@ -1,12 +1,13 @@
 #include "json.hpp"
 
+#include <iostream>
+
 #include "thirdparty/rapidjson/stringbuffer.h"
 #include "thirdparty/rapidjson/writer.h"
-#include <iostream>
 
 namespace vectordb {
 
-Json::Json() : doc_(nlohmann::json()) {} 
+Json::Json() : doc_(nlohmann::json()) {}
 
 bool Json::LoadFromString(const std::string& json_string) {
   try {
@@ -56,6 +57,14 @@ std::string Json::GetString() const {
 
 int64_t Json::GetInt() const {
   return doc_.get<int64_t>();
+}
+
+bool Json::IsNumber() const {
+  return doc_.is_number();
+}
+
+bool Json::IsString() const {
+  return doc_.is_string();
 }
 
 double Json::GetDouble() const {

--- a/engine/utils/json.hpp
+++ b/engine/utils/json.hpp
@@ -23,12 +23,12 @@ class Json {
   double GetDouble() const;
   bool GetBool() const;
   size_t GetSize() const;
-  Json GetObject(const std::string& key) const;                      // Get nested object
-  Json Get(const std::string& key) const;                      // Get nested json
+  Json GetObject(const std::string& key) const;  // Get nested object
+  Json Get(const std::string& key) const;        // Get nested json
   size_t GetArraySize(const std::string& key) const;
   Json GetArrayElement(const std::string& key, size_t index) const;  // Get specific element from array
-  Json GetArray(const std::string& key) const;  // Get specific element from array
-  Json GetArrayElement(size_t index) const;  // Get specific element from array
+  Json GetArray(const std::string& key) const;                       // Get specific element from array
+  Json GetArrayElement(size_t index) const;                          // Get specific element from array
   bool HasMember(const std::string& key) const;
 
   void SetString(const std::string& key, const std::string& value);
@@ -47,6 +47,9 @@ class Json {
   void AddDoubleToArray(double value);
   void AddBoolToArray(bool value);
   void AddObjectToArray(const Json& object);
+  bool IsNumber() const;
+  bool IsString() const;
+
  private:
   nlohmann::json doc_;
 };
@@ -55,7 +58,7 @@ class Json {
 
 /**
  * Usage example:
- * 
+ *
   std::string json_string = R"({
         "name": "John Doe",
         "age": 30,


### PR DESCRIPTION
# What change is proposed in this PR?
Delete by PK support
  - add delete by PK interface in
     - server-side interface
     - python binding
  - implement the delete WAL
  - filter out deleted entries from the search result

# How is it tested?
In `test.py`, deleted 4 / 5 entries and make another query, only 1 result is returned:

```
~/vectordb/engine$ ./test.sh --single-thread
running single-thread mode
Processing file: /tmp/db2/0/wal/1693632266.log
primary key [1] already exists, skipping.
successfully inserted 5 records. skipped 1 records with primary key values that already exist.
0 [{'@distance': 0.00010000040492741391, 'Doc': 'Moscow', 'Embedding': [0.36000001430511475, 0.550000011920929, 0.4699999988079071, 0.9399999976158142], 'ID': 3}, {'@distance': 0.21769997477531433, 'Doc': 'Berlin', 'Embedding': [0.05000000074505806, 0.6100000143051147, 0.7599999904632568, 0.7400000095367432], 'ID': 1}]
deleting pk  [1, 2, 3, 4]
OK
delete_by_pk return code: 0
0 [{'@distance': 0.46149998903274536, 'Doc': 'Shanghai', 'Embedding': [0.23999999463558197, 0.18000000715255737, 0.2199999988079071, 0.4399999976158142], 'ID': 5}]
```