### PR TITLE
Add PostHog telemetry to heartbeat.sh

### DIFF
--- a/engine/scripts/heartbeat.sh
+++ b/engine/scripts/heartbeat.sh
@@ -5,6 +5,7 @@
 STARTUP_FILE=".startup_file"
 CONFIG_URL="https://config.epsilla.com/candidate.json"
 QUERY_URL="https://api.ipify.org"
+POSTHOG_API_KEY="phc_HoDjIs8hJa1dHPB6dudGwCCk5Q8t3lUaAQDWzhq9DDS"
 
 SENTRY_DSN=`curl $CONFIG_URL | grep heartbeat | awk -F '"' '{print $(NF-1)}'`
 SENTRY_HOST=`echo $SENTRY_DSN | sed -e "s/[^/]*\/\/\([^@]*@\)\?\([^:/]*\).*/\2/"`
@@ -45,20 +46,18 @@ if [ ! -f "${STARTUP_FILE}" ]; then
       \"message\": \"Epsilla VectorDB starts up at ${EXTERNAL_IP}\"
     }
   }";
-  curl -v -L --header "Content-Type: application/json" \
-  "https://app.posthog.com/capture/" \
+  curl -X POST -L --header "Content-Type: application/json" \
+  "https://epsilla.ph.getmentioned.ai/ingest/capture/" \
   --data "{
     \"event\": \"VectorDB started\",
-    \"api_key\": \"phc_HoDjIs8hJa1dHPB6dudGwCCk5Q8t3lUaAQDWzhq9DDS\",
+    \"api_key\": \"${POSTHOG_API_KEY}\",
     \"distinct_id\": \"${DISTINCT_ID}\",
     \"properties\": {
       \"version\": \"latest\",
       \"internal_ip\": \"${INTERNAL_IP}\",
-      \"external_ip\": \"${EXTERNAL_IP}\",
-      \"timestamp\": \"${TIMESTAMP}\",
+      \"external_ip\": \"${EXTERNAL_IP}\"
     },
-    \"timestamp": \"[optional timestamp in ISO 8601 format]\"
-  }"; 
+  }";
   touch ${STARTUP_FILE};
   echo "${EXTERNAL_IP}" > ${STARTUP_FILE};
 fi
@@ -88,4 +87,16 @@ curl -X POST \
     \"message\": \"HeartBeat\"
   }
 }"
+curl -X POST -L --header "Content-Type: application/json" \
+  "https://epsilla.ph.getmentioned.ai/ingest/capture/" \
+  --data "{
+    \"event\": \"VectorDB heartbeat\",
+    \"api_key\": \"${POSTHOG_API_KEY}\",
+    \"distinct_id\": \"${DISTINCT_ID}\",
+    \"properties\": {
+      \"version\": \"latest\",
+      \"internal_ip\": \"${INTERNAL_IP}\",
+      \"external_ip\": \"${EXTERNAL_IP}\"
+    },
+  }";
 

--- a/engine/scripts/heartbeat.sh
+++ b/engine/scripts/heartbeat.sh
@@ -56,7 +56,7 @@ if [ ! -f "${STARTUP_FILE}" ]; then
       \"version\": \"latest\",
       \"internal_ip\": \"${INTERNAL_IP}\",
       \"external_ip\": \"${EXTERNAL_IP}\"
-    },
+    }
   }";
   touch ${STARTUP_FILE};
   echo "${EXTERNAL_IP}" > ${STARTUP_FILE};
@@ -97,6 +97,6 @@ curl -X POST -L --header "Content-Type: application/json" \
       \"version\": \"latest\",
       \"internal_ip\": \"${INTERNAL_IP}\",
       \"external_ip\": \"${EXTERNAL_IP}\"
-    },
+    }
   }";
 


### PR DESCRIPTION
This PR adds PostHog requests to heartbeat.sh. It allows PostHog to collect telemetry when vectordb server is running.

I tested this change in the following way
1. getting a bash shell in the docker container
2. paste the new `heartbeat.sh` script in
3. run the heartbeat script manually
4. confirm the telemetry event in PostHog

Because we don't have access to machine ID from the host system in the docker container, we generate a hash of (hostname, internal_ip, external_ip). Hostname is the docker container ID by default, which is random.

<img width="1187" alt="Screenshot 2023-10-10 at 7 39 47 PM" src="https://github.com/epsilla-cloud/vectordb/assets/5278006/6445a3e0-c131-4059-9b78-ff8a22873373">
