### PR TITLE
Support for Nomic Embedding API and Nomic Embed

### DIFF
--- a/engine/server/web_server/web_controller.hpp
+++ b/engine/server/web_server/web_controller.hpp
@@ -102,6 +102,10 @@ class WebController : public oatpp::web::server::api::ApiController {
     if (headerValue != nullptr) {
       headers[MIXEDBREADAI_KEY_HEADER] = headerValue->c_str();
     }
+    headerValue = request->getHeader(NOMIC_KEY_HEADER);
+    if (headerValue != nullptr) {
+      headers[NOMIC_KEY_HEADER] = headerValue->c_str();
+    }
 
     std::string db_path = parsedBody.GetString("path");
     std::string db_name = parsedBody.GetString("name");
@@ -416,6 +420,10 @@ class WebController : public oatpp::web::server::api::ApiController {
     if (headerValue != nullptr) {
       headers[MIXEDBREADAI_KEY_HEADER] = headerValue->c_str();
     }
+    headerValue = request->getHeader(NOMIC_KEY_HEADER);
+    if (headerValue != nullptr) {
+      headers[NOMIC_KEY_HEADER] = headerValue->c_str();
+    }
 
     auto data = parsedBody.GetArray("data");
     vectordb::Status insert_status = db_server->Insert(db_name, table_name, data, headers, upsert);
@@ -649,6 +657,10 @@ class WebController : public oatpp::web::server::api::ApiController {
     headerValue = request->getHeader(MIXEDBREADAI_KEY_HEADER);
     if (headerValue != nullptr) {
       headers[MIXEDBREADAI_KEY_HEADER] = headerValue->c_str();
+    }
+    headerValue = request->getHeader(NOMIC_KEY_HEADER);
+    if (headerValue != nullptr) {
+      headers[NOMIC_KEY_HEADER] = headerValue->c_str();
     }
 
     vectordb::Json result;

--- a/engine/services/embedding_service.cpp
+++ b/engine/services/embedding_service.cpp
@@ -83,7 +83,7 @@ Status EmbeddingService::denseEmbedDocuments(
         if (headers.find(MIXEDBREADAI_KEY_HEADER) == headers.end()) {
           return Status(INVALID_PAYLOAD, "Missing mixedbread ai API key.");
         }
-        mixedbreadai_key = headers[NOMIC_KEY_HEADER];
+        mixedbreadai_key = headers[MIXEDBREADAI_KEY_HEADER];
       } else if (server::CommonUtil::StartsWith(model_name, "nomic/")) {
         if (headers.find(NOMIC_KEY_HEADER) == headers.end()) {
           return Status(INVALID_PAYLOAD, "Missing Nomic API key.");

--- a/engine/services/embedding_service.cpp
+++ b/engine/services/embedding_service.cpp
@@ -149,6 +149,7 @@ Status EmbeddingService::denseEmbedQuery(
       std::string jinaai_key = "";
       std::string voyageai_key = "";
       std::string mixedbreadai_key = "";
+      std::string nomic_key = "";
       // Inject 3rd party service key based on their model name.
       if (server::CommonUtil::StartsWith(model_name, "openai/")) {
         if (headers.find(OPENAI_KEY_HEADER) == headers.end()) {

--- a/engine/services/embedding_service.cpp
+++ b/engine/services/embedding_service.cpp
@@ -62,6 +62,7 @@ Status EmbeddingService::denseEmbedDocuments(
       std::string jinaai_key = "";
       std::string voyageai_key = "";
       std::string mixedbreadai_key = "";
+      std::string nomic_key = "";
       // Inject 3rd party service key based on their model name.
       if (server::CommonUtil::StartsWith(model_name, "openai/")) {
         if (headers.find(OPENAI_KEY_HEADER) == headers.end()) {
@@ -82,7 +83,12 @@ Status EmbeddingService::denseEmbedDocuments(
         if (headers.find(MIXEDBREADAI_KEY_HEADER) == headers.end()) {
           return Status(INVALID_PAYLOAD, "Missing mixedbread ai API key.");
         }
-        mixedbreadai_key = headers[MIXEDBREADAI_KEY_HEADER];
+        mixedbreadai_key = headers[NOMIC_KEY_HEADER];
+      } else if (server::CommonUtil::StartsWith(model_name, "nomic/")) {
+        if (headers.find(NOMIC_KEY_HEADER) == headers.end()) {
+          return Status(INVALID_PAYLOAD, "Missing Nomic API key.");
+        }
+        nomic_key = headers[NOMIC_KEY_HEADER];
       }
 
       // Constructing documents list from attr_column_container
@@ -91,7 +97,7 @@ Status EmbeddingService::denseEmbedDocuments(
         // Assuming attr_column_container[idx] returns a string or can be converted to string
         requestBody->documents->push_back(oatpp::String(std::get<std::string>(attr_column_container[idx]).c_str()));
       }
-      auto response = m_client->denseEmbedDocuments("/v1/embeddings", openai_key, jinaai_key, voyageai_key, mixedbreadai_key, requestBody);
+      auto response = m_client->denseEmbedDocuments("/v1/embeddings", openai_key, jinaai_key, voyageai_key, mixedbreadai_key, nomic_key, requestBody);
       auto responseBody = response->readBodyToString();
       // std::cout << "Embedding response: " << responseBody->c_str() << std::endl;
       vectordb::Json json;
@@ -164,9 +170,15 @@ Status EmbeddingService::denseEmbedQuery(
           return Status(INVALID_PAYLOAD, "Missing mixedbread ai API key.");
         }
         mixedbreadai_key = headers[MIXEDBREADAI_KEY_HEADER];
+      } else if (server::CommonUtil::StartsWith(model_name, "nomic/")) {
+        if (headers.find(NOMIC_KEY_HEADER) == headers.end()) {
+          return Status(INVALID_PAYLOAD, "Missing Nomic API key.");
+        }
+        nomic_key = headers[NOMIC_KEY_HEADER];
       }
 
-      auto response = m_client->denseEmbedDocuments("/v1/embeddings", openai_key, jinaai_key, voyageai_key, mixedbreadai_key, requestBody);
+
+      auto response = m_client->denseEmbedDocuments("/v1/embeddings", openai_key, jinaai_key, voyageai_key, mixedbreadai_key, nomic_key, requestBody);
       auto responseBody = response->readBodyToString();
       // std::cout << "Embedding response: " << responseBody->c_str() << std::endl;
       vectordb::Json json;
@@ -192,7 +204,7 @@ Status EmbeddingService::denseEmbedQuery(
     std::this_thread::sleep_for(std::chrono::seconds(delaySec));
     std::cout << "Retry embedding the query." << std::endl;
   }
-  return Status(INFRA_UNEXPECTED_ERROR, "Failed to embbed the query.");
+  return Status(INFRA_UNEXPECTED_ERROR, "Failed to embed the query.");
 }
 
 }  // namespace engine

--- a/engine/services/embedding_service.cpp
+++ b/engine/services/embedding_service.cpp
@@ -84,7 +84,7 @@ Status EmbeddingService::denseEmbedDocuments(
           return Status(INVALID_PAYLOAD, "Missing mixedbread ai API key.");
         }
         mixedbreadai_key = headers[MIXEDBREADAI_KEY_HEADER];
-      } else if (server::CommonUtil::StartsWith(model_name, "nomic/")) {
+      } else if (server::CommonUtil::StartsWith(model_name, "nomicai/")) {
         if (headers.find(NOMIC_KEY_HEADER) == headers.end()) {
           return Status(INVALID_PAYLOAD, "Missing Nomic API key.");
         }
@@ -171,7 +171,7 @@ Status EmbeddingService::denseEmbedQuery(
           return Status(INVALID_PAYLOAD, "Missing mixedbread ai API key.");
         }
         mixedbreadai_key = headers[MIXEDBREADAI_KEY_HEADER];
-      } else if (server::CommonUtil::StartsWith(model_name, "nomic/")) {
+      } else if (server::CommonUtil::StartsWith(model_name, "nomicai/")) {
         if (headers.find(NOMIC_KEY_HEADER) == headers.end()) {
           return Status(INVALID_PAYLOAD, "Missing Nomic API key.");
         }

--- a/engine/services/embedding_service.hpp
+++ b/engine/services/embedding_service.hpp
@@ -44,7 +44,7 @@ class MyApiClient : public oatpp::web::client::ApiClient {
   API_CLIENT_INIT(MyApiClient)
 
   API_CALL("GET", "{path}", getEmbeddings, PATH(String, path))
-  API_CALL("POST", "{path}", denseEmbedDocuments, PATH(String, path), HEADER(String, openaiHeader, OPENAI_KEY_HEADER), HEADER(String, jinaaiHeader, JINAAI_KEY_HEADER), HEADER(String, voyageaiHeader, VOYAGEAI_KEY_HEADER), HEADER(String, mixedbreadaiHeader, MIXEDBREADAI_KEY_HEADER), BODY_DTO(Object<EmbeddingRequestBody>, body))
+  API_CALL("POST", "{path}", denseEmbedDocuments, PATH(String, path), HEADER(String, openaiHeader, OPENAI_KEY_HEADER), HEADER(String, jinaaiHeader, JINAAI_KEY_HEADER), HEADER(String, voyageaiHeader, VOYAGEAI_KEY_HEADER), HEADER(String, mixedbreadaiHeader, MIXEDBREADAI_KEY_HEADER), HEADER(String, nomicHeader, NOMIC_KEY_HEADER), BODY_DTO(Object<EmbeddingRequestBody>, body))
 
 
  #include OATPP_CODEGEN_END(ApiClient) //<- End codegen

--- a/engine/utils/constants.hpp
+++ b/engine/utils/constants.hpp
@@ -5,4 +5,5 @@ namespace vectordb {
   constexpr const char* JINAAI_KEY_HEADER = "X-JinaAI-API-Key";
   constexpr const char* VOYAGEAI_KEY_HEADER = "X-VoyageAI-API-Key";
   constexpr const char* MIXEDBREADAI_KEY_HEADER = "X-MixedbreadAI-API-Key";
+  constexpr const char* NOMIC_KEY_HEADER = "X-NOMIC-API-Key";
 }  // namespace vectordb


### PR DESCRIPTION
Initial PR:

The Nomic Embedding API does not have the same JSON schema as the OpenAI API - the code in this PR assumes that it does.

I am not exactly sure how the epsilla develoeprs want to handle special casing the endpoint. It needs:
- `texts`: a list of text documents
- `model`: the nomic embedding model
- `task_type`: the task you are using the embedding for 

Here is the official API Reference: https://docs.nomic.ai/reference/endpoints/nomic-embed-text