### PR TITLE
Support variable embedding dimensions

### DIFF
--- a/engine/db/catalog/meta_types.hpp
+++ b/engine/db/catalog/meta_types.hpp
@@ -69,6 +69,7 @@ struct Index {
   std::string embedding_model_name_;
   int64_t src_field_id_ = 0;
   int64_t tgt_field_id_ = 0;
+  int64_t dimensions = 0;
 };
 
 struct TableSchema {

--- a/engine/db/db_server.cpp
+++ b/engine/db/db_server.cpp
@@ -421,7 +421,8 @@ Status DBServer::SearchByContent(
       query,
       denseQueryVec,
       query_dimension,
-      headers
+      headers,
+      index.dimensions > 0
     );
 
     if (!status.ok()) {

--- a/engine/db/table_segment_mvp.cpp
+++ b/engine/db/table_segment_mvp.cpp
@@ -708,7 +708,8 @@ Status TableSegmentMVP::Insert(meta::TableSchema& table_schema, Json& records, i
       record_number_,
       cursor,
       table_schema.fields_[index.tgt_field_id_].vector_dimension_,
-      headers
+      headers,
+      index.dimensions > 0
     );
     if (!status.ok()) {
       std::cerr << "embedding service error: " << status.message() << std::endl;

--- a/engine/server/web_server/web_controller.hpp
+++ b/engine/server/web_server/web_controller.hpp
@@ -278,6 +278,9 @@ class WebController : public oatpp::web::server::api::ApiController {
         } else {
           index.embedding_model_name_ = vectordb::engine::meta::DEFAULT_MODEL_NAME;
         }
+        if (body_index.HasMember("dimensions")) {
+          index.dimensions = body_index.GetInt("dimensions");
+        }
         table_schema.indices_.push_back(index);
       }
     }

--- a/engine/services/embedding_service.hpp
+++ b/engine/services/embedding_service.hpp
@@ -34,6 +34,7 @@ class EmbeddingRequestBody: public oatpp::DTO {
 
   DTO_FIELD(String, model);
   DTO_FIELD(List<String>, documents);
+  DTO_FIELD(Int32, dimensions);
 };
 
 #include OATPP_CODEGEN_END(DTO) ///< End DTO codegen section
@@ -54,6 +55,7 @@ struct EmbeddingModel {
   std::string model;
   size_t dim;
   bool dense;
+  bool dimensionReduction;
   // std::string description;
   // double size_in_GB;
 };
@@ -70,14 +72,16 @@ public:
     size_t start_record,
     size_t end_record,
     size_t dimension,
-    std::unordered_map<std::string, std::string> &headers
+    std::unordered_map<std::string, std::string> &headers,
+    bool isReducingDimension
   );
   Status denseEmbedQuery(
     const std::string& model_name,
     const std::string &query,
     std::vector<engine::DenseVectorElement> &denseQueryVec,
     size_t dimension,
-    std::unordered_map<std::string, std::string> &headers
+    std::unordered_map<std::string, std::string> &headers,
+    bool isReducingDimension
   );
 
 private:


### PR DESCRIPTION
Usage Example:
```
POST http://localhost:8888/api/MyDB/schema/tables
{
    "name": "MyTable1293",
    "returnTableId": true,
    "fields": [
        {
        "name": "ID",
        "dataType": "BIGINT",
        "primaryKey": true
        },
        {
        "name": "Document",
        "dataType": "STRING"
        }
    ],
    "indices": [
        {
            "name": "MyIndex1",
            "field": "Document",
            "model": "openai/text-embedding-3-small",
            "dimensions": 128
        }
    ]
}